### PR TITLE
Support comma separated values

### DIFF
--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -497,6 +497,27 @@ export default function adExact(width, height) {
 "
 `;
 
+exports[`transform multiple comma separated values 1`] = `
+"import { css } from '@emotion/core';
+
+export default css\`
+  transition: opacity ease-out 1s, transform ease-in 1s;
+\`;
+"
+`;
+
+exports[`transform multiple comma separated variables 1`] = `
+"import { css } from '@emotion/core';
+
+const transition2 = 'transform ease-in 1s';
+const transition1 = 'opacity ease-out 1s';
+
+export default css\`
+  transition: \${transition1}, \${transition2};
+\`;
+"
+`;
+
 exports[`transform multiple nested 1`] = `
 "import { css } from '@emotion/core';
 import { variables as vars } from '@domain-group/fe-brary';

--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -964,7 +964,7 @@ exports[`transform vars referencing fe-brary variables 1`] = `
 import { fooBarBaz } from '../variables';
 
 export const agentAvatarBorderExperimentColor = '#979797';
-export const agentBoxBoxShadowLeftRight = \`inset -1px 0 0 0 $agent-box-border-color-lighter inset 1px 0 0 0 $agent-box-border-color-light\`;
+export const agentBoxBoxShadowLeftRight = \`inset -1px 0 0 0 $agent-box-border-color-lighter, inset 1px 0 0 0 $agent-box-border-color-light\`;
 export const fooBar = \`\${fooBarBaz}\`;
 export const agentNameSize = \`\${vars.font.h5FontSize}\`;
 "

--- a/transform.js
+++ b/transform.js
@@ -52,9 +52,11 @@ const processRoot = (root, filePath) => {
 
   function handleSassVar(decl) {
     let values;
+    let separator = ' ';
 
     if (decl.value.includes(',') && postcss.list.comma(decl.value)[0] !== decl.value) {
       values = postcss.list.comma(decl.value);
+      separator = ', ';
     } else if (decl.value.includes(' ') && postcss.list.space(decl.value)[0] !== decl.value) {
       values = postcss.list.space(decl.value);
     } else {
@@ -96,7 +98,7 @@ const processRoot = (root, filePath) => {
 
         return string;
       })
-      .join(' ');
+      .join(separator);
   }
 
   function handleSassVarUnescaped(value) {

--- a/transform.test.js
+++ b/transform.test.js
@@ -954,6 +954,28 @@ describe('transform', () => {
     ).toMatchSnapshot();
   });
 
+  it('multiple comma separated values', () => {
+    expect(
+      transform(`
+        .element {
+          transition: opacity ease-out 1s, transform ease-in 1s;
+        }
+      `),
+    ).toMatchSnapshot();
+  });
+
+  it('multiple comma separated variables', () => {
+    expect(
+      transform(`
+        $transition1: opacity ease-out 1s;
+        $transition2: transform ease-in 1s;
+        .element {
+          transition: $transition1, $transition2;
+        }
+      `),
+    ).toMatchSnapshot();
+  });
+
   it.skip('pseduo elements and combinators', () => {
     expect(
       transform(`


### PR DESCRIPTION
Currently comma-separated values are not supported correctly - the comma is stripped.

E.g.

```
.element {
    transition: opacity 1s, transform 2s;
}
```
would be translated to the following invalid declaration:
```
const element = css`{
    transition: opacity 1s transform 2s;
}`
```

Added tests and updated a test case that already exhibited this issue.